### PR TITLE
Pull Request: Add Option for Building a Specific Package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   post-test:
     description: "The command to be run after the test process."
     required: false
+  sepecific-package:
+    description: "The Command to only build specified pakage."
+    required: false
 runs:
   using: 'docker'
   image: 'dind/Dockerfile'
@@ -50,3 +53,4 @@ runs:
     - '${{ inputs.post-build }}'
     - '${{ inputs.pre-test }}'
     - '${{ inputs.post-test }}'
+    - '${{ inputs.specific-package }}'

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
   post-test:
     description: "The command to be run after the test process."
     required: false
-  sepecific-package:
-    description: "The Command to only build specified pakage."
+  specific-package:
+    description: "The command to only build specified package."
     required: false
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'ROS 2 CI'
+name: 'mjlee111 ROS 2 CI'
 description: 'Continuous integration for ROS 2 project'
-author: "ICHIRO ITS"
+author: "mjlee111"
 branding:
   icon: "activity"
   color: "gray-dark"

--- a/dind/entrypoint.sh
+++ b/dind/entrypoint.sh
@@ -10,7 +10,7 @@ PRE_BUILD="${7}"
 POST_BUILD="${8}"
 PRE_TEST="${9}"
 POST_TEST="${10}"
-
+SPECIFIC_PACKAGE="${11}"
 echo ''
 echo '======== Running the Docker daemon ========'
 echo ''
@@ -43,4 +43,5 @@ docker run \
   --env POST_BUILD="${POST_BUILD}" \
   --env PRE_TEST="${PRE_TEST}" \
   --env POST_TEST="${POST_TEST}" \
+  --env SPECIFIC_PACKAGE="${SPECIFIC_PACKAGE}" \
   --rm ros2-ci:latest || exit $?

--- a/dind/ros2/entrypoint.bash
+++ b/dind/ros2/entrypoint.bash
@@ -114,20 +114,42 @@ then
   cd /ws/repo && echo "$PRE_TEST" && eval "$PRE_TEST" || exit $?
 fi
 
-echo ''
-echo '======== Testing the workspace ========'
-echo ''
+if [ ! -z "$SPECIFIC_PACKAGE" ]
+then
+  echo ''
+  echo '======== Running the specific package command ========'
+  echo ''
 
-cd /ws && colcon test \
-  --event-handlers console_cohesion+ \
+  cd /ws && colcon test \
+    --event-handlers console_cohesion+ \
+    --pytest-with-coverage \
+    --return-code-on-test-failure $SPECIFIC_PACKAGE || exit $?
+    
+  mkdir /ws/repo/.ws \
+    && cp -r /ws/build /ws/repo/.ws \
+    && cp -r /ws/log /ws/repo/.ws \
+    && cp -r /ws/install /ws/repo/.ws \
+    || exit $?
+fi
+
+if [ -z "$SPECIFIC_PACKAGE" ]
+then
+
+  echo ''
+  echo '======== Testing the workspace ========'
+  echo ''
+
+  cd /ws && colcon test \
+    --event-handlers console_cohesion+ \
   --pytest-with-coverage \
   --return-code-on-test-failure || exit $?
 
-mkdir /ws/repo/.ws \
-  && cp -r /ws/build /ws/repo/.ws \
-  && cp -r /ws/log /ws/repo/.ws \
-  && cp -r /ws/install /ws/repo/.ws \
-  || exit $?
+  mkdir /ws/repo/.ws \
+    && cp -r /ws/build /ws/repo/.ws \
+    && cp -r /ws/log /ws/repo/.ws \
+    && cp -r /ws/install /ws/repo/.ws \
+    || exit $?
+fi
 
 if [ ! -z "$POST_TEST" ]
 then

--- a/dind/ros2/entrypoint.bash
+++ b/dind/ros2/entrypoint.bash
@@ -99,6 +99,18 @@ then
   source install/setup.bash || exit $?
 fi
 
+if [ ! -z "$SPECIFIC_PACKAGE" ]
+then
+  echo ''
+  echo '======== Building the specific package ========'
+  echo ''
+
+  cd /ws && colcon build \
+    --packages-select $SPECIFIC_PACKAGE \
+    --event-handlers console_cohesion+ \
+    --cmake-args || exit $?
+fi
+
 if [ ! -z "$POST_BUILD" ]
 then
   echo ''

--- a/dind/ros2/entrypoint.bash
+++ b/dind/ros2/entrypoint.bash
@@ -121,10 +121,11 @@ then
   echo ''
 
   cd /ws && colcon test \
+    --packages-select $SPECIFIC_PACKAGE \
     --event-handlers console_cohesion+ \
     --pytest-with-coverage \
-    --return-code-on-test-failure $SPECIFIC_PACKAGE || exit $?
-    
+    --return-code-on-test-failure || exit $?
+
   mkdir /ws/repo/.ws \
     && cp -r /ws/build /ws/repo/.ws \
     && cp -r /ws/log /ws/repo/.ws \

--- a/dind/ros2/entrypoint.bash
+++ b/dind/ros2/entrypoint.bash
@@ -86,15 +86,18 @@ then
   cd /ws/repo && echo "$PRE_BUILD" && eval "$PRE_BUILD" || exit $?
 fi
 
-echo ''
-echo '======== Building the workspace ========'
-echo ''
+if [ -z "$SPECIFIC_PACKAGE" ]
+then
+  echo ''
+  echo '======== Building the workspace ========'
+  echo ''
 
-cd /ws && colcon build \
-  --event-handlers console_cohesion+ \
-  --cmake-args || exit $?
+  cd /ws && colcon build \
+    --event-handlers console_cohesion+ \
+    --cmake-args || exit $?
 
-source install/setup.bash || exit $?
+  source install/setup.bash || exit $?
+fi
 
 if [ ! -z "$POST_BUILD" ]
 then


### PR DESCRIPTION
**Summary** 
This PR adds an option to the GitHub Actions workflow for building a specific package within the repository. Previously, the CI process would build all packages, but with this update, users can now specify a particular package to be built. This enhancement provides more flexibility and efficiency, especially when only one package requires testing or development, reducing overall build times and resource consumption.

**Changes** 
Updated the GitHub Actions workflow to include an input parameter for selecting a specific package.
Modified the CI logic to conditionally build the selected package if specified.
Fallback to building all packages if no specific package is provided.

**Benefits** 
Faster build times when only one package needs to be tested.
Reduces resource usage by skipping unnecessary builds of unrelated packages.
Simplifies the development and testing process for contributors focusing on a single package.

**Testing** 
Verified that the workflow correctly builds only the specified package.
Confirmed that the workflow defaults to building all packages when no package is specified.